### PR TITLE
Rename "api_root" to "owner_url"

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,16 +84,16 @@ let ses = null;
 let fs = null;
 
 async function startup() {
-  const api_root = localStorage.getItem('snfs_api_root') || 'https://selfnetfs-api.home.arpa/myowner';
+  const owner_url = localStorage.getItem('snfs_owner_url') || 'https://selfnetfs-api.home.arpa/myowner';
   const session_token = localStorage.getItem('snfs_session_token');
-  api = new SNFS.Http(api_root);
+  api = new SNFS.Http(owner_url);
   try {
     ses = await api.resume(session_token);
     console.log('Successfully resumed session.');
   } catch (err) {
     console.log('Couldn\'t resume, logging in again.');
     ses = await api.login({ name: 'myuser', password: 'password' });
-    localStorage.setItem('snfs_api_root', api_root);
+    localStorage.setItem('snfs_owner_url', owner_url);
     localStorage.setItem('snfs_session_token', ses.info().session_token);
   }
   fs = await ses.fs();

--- a/browser/http.ts
+++ b/browser/http.ts
@@ -70,16 +70,16 @@ async function apirequest(endpoint: string, payload: any) {
 }
 
 export class Http extends SNFS {
-  _api_root: string;
+  _owner_url: string;
 
-  constructor(api_root: string) {
+  constructor(owner_url: string) {
     super();
 
-    this._api_root = api_root;
+    this._owner_url = owner_url;
   }
 
   async login(options: LoginOptions): Promise<Session> {
-    const result = await apirequest(urljoin(this._api_root, 'login'), {
+    const result = await apirequest(urljoin(this._owner_url, 'login'), {
       name: options.name,
       password: options.password,
     });
@@ -100,7 +100,7 @@ export class Http extends SNFS {
     if (typeof pool !== 'string') {
       throw new SNFSError('Invalid token.');
     }
-    const result = await apirequest(urljoin(this._api_root, pool, 'resume'), {
+    const result = await apirequest(urljoin(this._owner_url, pool, 'resume'), {
     });
     return new SessionHttp(this, pool, result.userno);
   }
@@ -108,7 +108,7 @@ export class Http extends SNFS {
 
 export class SessionHttp extends Session {
   _snfs: Http;
-  _api_root: string;
+  _owner_url: string;
   _userno: string;
   pool: string;
 
@@ -116,7 +116,7 @@ export class SessionHttp extends Session {
     super();
 
     this._snfs = snfs;
-    this._api_root = snfs._api_root;
+    this._owner_url = snfs._owner_url;
     this._userno = userno;
     this.pool = pool;
   }
@@ -131,26 +131,26 @@ export class SessionHttp extends Session {
   }
 
   async detail(): Promise<SessionDetail> {
-    const result = await apirequest(urljoin(this._api_root, this.pool, 'sesdetail'), {
+    const result = await apirequest(urljoin(this._owner_url, this.pool, 'sesdetail'), {
     });
     return result;
   }
 
   async logout(): Promise<LogoutResult> {
-    const result = await apirequest(urljoin(this._api_root, this.pool, 'logout'), {
+    const result = await apirequest(urljoin(this._owner_url, this.pool, 'logout'), {
     });
     return result;
   }
 
   async useradd(options: UseraddOptions): Promise<UserInfo> {
-    const result = await apirequest(urljoin(this._api_root, this.pool, 'useradd'), {
+    const result = await apirequest(urljoin(this._owner_url, this.pool, 'useradd'), {
       options,
     });
     return result;
   }
 
   async usermod(userno: string, options: UsermodOptions): Promise<UserInfo> {
-    const result = await apirequest(urljoin(this._api_root, this.pool, 'usermod'), {
+    const result = await apirequest(urljoin(this._owner_url, this.pool, 'usermod'), {
       userno,
       options,
     });
@@ -158,48 +158,48 @@ export class SessionHttp extends Session {
   }
 
   async userdel(userno: string): Promise<UserdelResult> {
-    const result = await apirequest(urljoin(this._api_root, this.pool, 'userdel'), {
+    const result = await apirequest(urljoin(this._owner_url, this.pool, 'userdel'), {
       userno,
     });
     return result;
   }
 
   async userlist(): Promise<UserInfo[]> {
-    const result = await apirequest(urljoin(this._api_root, this.pool, 'userlist'), {
+    const result = await apirequest(urljoin(this._owner_url, this.pool, 'userlist'), {
     });
     return result;
   }
 
   async fs(): Promise<FileSystem> {
-    const result = await apirequest(urljoin(this._api_root, this.pool, 'fs'), {
+    const result = await apirequest(urljoin(this._owner_url, this.pool, 'fs'), {
     });
-    return new FileSystemHttp(this._snfs, this._api_root, this.pool, result.fs_token, result.fsno, result.union);
+    return new FileSystemHttp(this._snfs, this._owner_url, this.pool, result.fs_token, result.fsno, result.union);
   }
 
   async fsget(fsno: string, options?: FsgetOptions): Promise<FileSystem> {
-    const result = await apirequest(urljoin(this._api_root, this.pool, 'fsget'), {
+    const result = await apirequest(urljoin(this._owner_url, this.pool, 'fsget'), {
       fsno,
       options,
     });
-    return new FileSystemHttp(this._snfs, this._api_root, this.pool, result.fs_token, result.fsno, result.union);
+    return new FileSystemHttp(this._snfs, this._owner_url, this.pool, result.fs_token, result.fsno, result.union);
   }
 
   async fsresume(fs_token: string): Promise<FileSystem> {
-    const result = await apirequest(urljoin(this._api_root, this.pool, 'fsresume'), {
+    const result = await apirequest(urljoin(this._owner_url, this.pool, 'fsresume'), {
       fs_token,
     });
-    return new FileSystemHttp(this._snfs, this._api_root, this.pool, fs_token, result.fsno, result.union);
+    return new FileSystemHttp(this._snfs, this._owner_url, this.pool, fs_token, result.fsno, result.union);
   }
 
   async fsadd(options: FsaddOptions): Promise<FSInfo> {
-    const result = await apirequest(urljoin(this._api_root, this.pool, 'fsadd'), {
+    const result = await apirequest(urljoin(this._owner_url, this.pool, 'fsadd'), {
       options,
     });
     return result;
   }
 
   async fsmod(fsno: string, options: FsmodOptions): Promise<FSInfo> {
-    const result = await apirequest(urljoin(this._api_root, this.pool, 'fsmod'), {
+    const result = await apirequest(urljoin(this._owner_url, this.pool, 'fsmod'), {
       fsno,
       options,
     });
@@ -207,14 +207,14 @@ export class SessionHttp extends Session {
   }
 
   async fsdel(fsno: string): Promise<FsdelResult> {
-    const result = await apirequest(urljoin(this._api_root, this.pool, 'fsdel'), {
+    const result = await apirequest(urljoin(this._owner_url, this.pool, 'fsdel'), {
       fsno,
     });
     return result;
   }
 
   async fslist(): Promise<FSInfo[]> {
-    const result = await apirequest(urljoin(this._api_root, this.pool, 'fslist'), {
+    const result = await apirequest(urljoin(this._owner_url, this.pool, 'fslist'), {
     });
     return result;
   }
@@ -222,17 +222,17 @@ export class SessionHttp extends Session {
 
 export class FileSystemHttp extends FileSystem {
   _snfs: Http;
-  _api_root: string;
+  _owner_url: string;
   _pool: string;
   _fs_token: string;
   _fsno: string;
   _union: string[];
 
-  constructor(snfs: Http, api_root: string, pool: string, fs_token: string, fsno: string, union: string[]) {
+  constructor(snfs: Http, owner_url: string, pool: string, fs_token: string, fsno: string, union: string[]) {
     super();
 
     this._snfs = snfs;
-    this._api_root = api_root;
+    this._owner_url = owner_url;
     this._pool = pool;
     this._fs_token = fs_token;
     this._fsno = fsno;
@@ -248,14 +248,14 @@ export class FileSystemHttp extends FileSystem {
   }
 
   async detail(): Promise<FileSystemDetail> {
-    const result = await apirequest(urljoin(this._api_root, this._pool, 'fsdetail'), {
+    const result = await apirequest(urljoin(this._owner_url, this._pool, 'fsdetail'), {
       fs_token: this._fs_token,
     });
     return result;
   }
 
   async readdir(path: string): Promise<ReaddirResult[]> {
-    const result = await apirequest(urljoin(this._api_root, this._pool, 'readdir'), {
+    const result = await apirequest(urljoin(this._owner_url, this._pool, 'readdir'), {
       fs_token: this._fs_token,
       path,
     });
@@ -263,7 +263,7 @@ export class FileSystemHttp extends FileSystem {
   }
 
   async stat(path: string): Promise<StatResult> {
-    const result = await apirequest(urljoin(this._api_root, this._pool, 'stat'), {
+    const result = await apirequest(urljoin(this._owner_url, this._pool, 'stat'), {
       fs_token: this._fs_token,
       path,
     });
@@ -273,7 +273,7 @@ export class FileSystemHttp extends FileSystem {
   }
 
   async writefile(path: string, data: Uint8Array, options?: WritefileOptions): Promise<WritefileResult> {
-    const result = await apirequest(urljoin(this._api_root, this._pool, 'writefile'), {
+    const result = await apirequest(urljoin(this._owner_url, this._pool, 'writefile'), {
       fs_token: this._fs_token,
       path,
       data: bufferToBase64(data),
@@ -283,7 +283,7 @@ export class FileSystemHttp extends FileSystem {
   }
 
   async readfile(path: string): Promise<ReadfileResult> {
-    const result = await apirequest(urljoin(this._api_root, this._pool, 'readfile'), {
+    const result = await apirequest(urljoin(this._owner_url, this._pool, 'readfile'), {
       fs_token: this._fs_token,
       path,
     });
@@ -292,7 +292,7 @@ export class FileSystemHttp extends FileSystem {
   }
 
   async unlink(path: string): Promise<UnlinkResult> {
-    const result = await apirequest(urljoin(this._api_root, this._pool, 'unlink'), {
+    const result = await apirequest(urljoin(this._owner_url, this._pool, 'unlink'), {
       fs_token: this._fs_token,
       path,
     });
@@ -300,7 +300,7 @@ export class FileSystemHttp extends FileSystem {
   }
 
   async move(path: string, newpath: string): Promise<MoveResult> {
-    const result = await apirequest(urljoin(this._api_root, this._pool, 'move'), {
+    const result = await apirequest(urljoin(this._owner_url, this._pool, 'move'), {
       fs_token: this._fs_token,
       path,
       newpath,

--- a/example/index.html
+++ b/example/index.html
@@ -24,9 +24,9 @@
     }
 
     async function main() {
-      const api_root = localStorage.getItem('snfs_api_root') ||  'https://selfnetfs-api.home.arpa/myowner';
+      const owner_url = localStorage.getItem('snfs_owner_url') ||  'https://selfnetfs-api.home.arpa/myowner';
       const session_token = localStorage.getItem('snfs_session_token');
-      api = new SNFS.Http(api_root);
+      api = new SNFS.Http(owner_url);
       try {
         ses = await api.resume(session_token);
         console.log('Successfully resumed session.');
@@ -34,7 +34,7 @@
         console.log('Couldn\'t resume, logging in again.');
       }
       ses = await api.login({ name: 'myuser', password: 'password' });
-      localStorage.setItem('snfs_api_root', api_root);
+      localStorage.setItem('snfs_owner_url', owner_url);
       localStorage.setItem('snfs_session_token', ses.info().session_token);
       fs = await ses.fs();
     }

--- a/example/shell.html
+++ b/example/shell.html
@@ -96,14 +96,14 @@
 
     commands.set('connect', async (...args) => {
       if (args.length != 3) {
-        shell.log('connect: usage: connect api_root user password');
+        shell.log('connect: usage: connect owner_url user password');
         return;
       }
-      const [api_root, name, password] = args;
-      api = new SNFS.Http(api_root);
+      const [owner_url, name, password] = args;
+      api = new SNFS.Http(owner_url);
       try {
         ses = await api.login({ name, password });
-        localStorage.setItem('snfs_api_root', api_root);
+        localStorage.setItem('snfs_owner_url', owner_url);
         localStorage.setItem('snfs_session_token', ses.info().session_token);
       } catch (err) {
         handleErr(err);
@@ -555,7 +555,7 @@
     });
 
     commands.set('help', async (...args) => {
-      shell.log('connect api_root user password');
+      shell.log('connect owner_url user password');
       shell.log('id');
       shell.log('useradd [--name name] [--password password] [--admin true/false] [--fs fsno] [--union fsno,fsno,...]');
       shell.log('usermod userno [--name new_name] [--password password] [--admin true/false] [--fs fsno] [--union fsno,fsno,...]');
@@ -620,9 +620,9 @@
 
     async function main() {
       shell.log('SelfNetFS Shell');
-      const api_root = localStorage.getItem('snfs_api_root');
+      const owner_url = localStorage.getItem('snfs_owner_url');
       const session_token = localStorage.getItem('snfs_session_token');
-      api = new SNFS.Http(api_root);
+      api = new SNFS.Http(owner_url);
       if (session_token != null) {
         shell.log(`Resuming session...`);
         try {

--- a/example/test.html
+++ b/example/test.html
@@ -29,7 +29,7 @@
         console.log('Successfully resumed session.');
       } catch (err) {
         console.log('Couldn\'t resume, logging in again.');
-        ses = await snfs.login({ owner_url, name: 'admin', password: 'password' });
+        ses = await snfs.login({ name: 'admin', password: 'password' });
         localStorage.setItem('snfs_test_owner_url', owner_url);
         localStorage.setItem('snfs_test_session_token', ses.info().session_token);
       }
@@ -132,7 +132,7 @@
           const fsinfo = await ses.fsadd({ name: 'testing' });
           await ses.useradd({ name: 'guest', password: 'password', fs: fsinfo.fsno  });
         }
-        let ses2 = await snfs.login({ owner_url: OWNER_URL, name: 'guest', password: 'password' });
+        let ses2 = await snfs.login({ name: 'guest', password: 'password' });
         let fs2 = await ses2.fs();
         {
           const entries = await fs2.readdir('/');

--- a/example/test.html
+++ b/example/test.html
@@ -9,7 +9,7 @@
   <script>
     'use strict';
 
-    const API_ROOT = 'https://selfnetfs-api.home.arpa/test';
+    const OWNER_URL = 'https://selfnetfs-api.home.arpa/test';
 
     async function makeMemory() {
       const snfs = new SNFS.Memory(SNFS.uuidgen, new SNFS.PasswordModuleNull());
@@ -21,16 +21,16 @@
 
     async function makeHttp() {
       let ses = null;
-      const api_root = localStorage.getItem('snfs_test_api_root') || API_ROOT;
+      const owner_url = localStorage.getItem('snfs_test_owner_url') || OWNER_URL;
       const session_token = localStorage.getItem('snfs_test_session_token');
-      const snfs = new SNFS.Http(api_root);
+      const snfs = new SNFS.Http(owner_url);
       try {
         ses = await snfs.resume(session_token);
         console.log('Successfully resumed session.');
       } catch (err) {
         console.log('Couldn\'t resume, logging in again.');
-        ses = await snfs.login({ api_root, name: 'admin', password: 'password' });
-        localStorage.setItem('snfs_test_api_root', api_root);
+        ses = await snfs.login({ owner_url, name: 'admin', password: 'password' });
+        localStorage.setItem('snfs_test_owner_url', owner_url);
         localStorage.setItem('snfs_test_session_token', ses.info().session_token);
       }
       await doCleanup(ses);
@@ -132,7 +132,7 @@
           const fsinfo = await ses.fsadd({ name: 'testing' });
           await ses.useradd({ name: 'guest', password: 'password', fs: fsinfo.fsno  });
         }
-        let ses2 = await snfs.login({ api_root: API_ROOT, name: 'guest', password: 'password' });
+        let ses2 = await snfs.login({ owner_url: OWNER_URL, name: 'guest', password: 'password' });
         let fs2 = await ses2.fs();
         {
           const entries = await fs2.readdir('/');


### PR DESCRIPTION
A straight forward rename of `api_root` and related to `owner_url` to more match the terminology that will be used in a user manual.